### PR TITLE
Feature/image-links

### DIFF
--- a/src/utils/md.ts
+++ b/src/utils/md.ts
@@ -68,6 +68,10 @@ export const todo = (text: string, checked: boolean) => {
 };
 
 export const image = (alt: string, href: string) => {
+  if (/^https?:\/\//.test(alt)) {
+    // if alt is an external url, turn it into a "image link"
+    return link(`![](${href})`, href);
+  }
   return `![${alt}](${href})`;
 };
 


### PR DESCRIPTION
Turn images into "image links" when alt is an URL.

This is the only way we can make images buttons in notion.

This behavior should be a graceful enhancement that shouldn't break normal usage or image captions.